### PR TITLE
dedupe_levenshtein_search 1.4.5 [fix-typo-in-name] :snowflake:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "dedupe_Lehvenshtein_search" %}
+{% set name = "dedupe_levenshtein_search" %}
 {% set version = "1.4.5" %}
 
 package:


### PR DESCRIPTION
dedupe_levenshtein_search 1.4.5 :snowflake:

**Destination channel:** Snowflake

### Links

- See AnacondaRecipes/dedupe_levenshtein_search-feedstock/pull/1
- This https://anaconda.org/sfe1ed40/dedupe_lehvenshtein_search

### Explanation of changes:

- fix name typo: it should be `dedupe_levenshtein_search` (without h after dedupe_le)
